### PR TITLE
Remove link to spam / malware site

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
 - [Kernel Source provided by Lenovo](https://smartsupport.lenovo.com/uk/en/products/smart/smart-home/smart-clock/za4r/downloads/driver-list/component?name=Software%20and%20Utilities) 
 - [Fuschia Board Drivers](https://fuchsia.googlesource.com/fuchsia/+/3a593fc8b3a7/src/devices/board/drivers/mt8167s_ref)
 - [Fuschia Board Ref](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/releases/f2/boards/mt8167s_ref.gni)
-- [Series of blog posts regarding running custom software on the Xiaomi variant of the smart clock, also includes some internal mediatek documentation pdf's](https://www.pigworld.pw/?p=126)
 
 ## Credits
 


### PR DESCRIPTION
Remove the link in the README that leads to a malicious website.

closes #4 